### PR TITLE
Remove online calendly link

### DIFF
--- a/contact-us.html
+++ b/contact-us.html
@@ -108,13 +108,18 @@
                             GUEST SPEAKERS
                         </h2>
                         <p class="col-12">
-                            Interested in or invited to participate in a guest speaking event? Please use one of the following
-                            links to plan the event with us!
+                            Interested in or invited to participate in a guest speaking event in person or online? Please use
+                            the following link to plan the event with us!
                         </p>
                         <p class="col-12 text-center">
-                            <span class="fw-bold">In Person:</span>&nbsp;<a class="text-primary" href="https://calendly.com/uvudataclub/guest-speaking-opportunity-in-person" target="_blank" rel="noopener noreferrer">calendly.com/in-person</a>
-                            <span class="fw-bold">|</span>
-                            <span class="fw-bold">Online/Remote:</span>&nbsp;<a class="text-primary" href="https://calendly.com/uvudataclub/guest-speaker-online" target="_blank" rel="noopener noreferrer">calendly.com/online</a>
+                            <span class="fw-bold">Schedule Guest Speaking Event:</span>
+                            <a
+                                class="text-primary"
+                                href="https://calendly.com/uvudataclub/guest-speaking-opportunity-in-person"
+                                target="_blank"
+                                rel="noopener noreferrer">
+                                calendly.com/guest-speaking-event
+                            </a>
                         </p>
                     </div>
                 </section>


### PR DESCRIPTION
Remove the link on the Contact Us page for scheduling an online guest speaking event through Calendly since we can only have one type of event with Calendly free.