### PR TITLE
Fix lightning talks link opening in same tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,7 +170,10 @@
                             <img src="/imgs/news-slide-secretary-ad.png" class="d-block w-100" alt="...">
                         </div>
                         <div class="carousel-item">
-                            <a href="https://www.meetup.com/utah-data-engineering-meetup/events/290681404/">
+                            <a
+                                href="https://www.meetup.com/utah-data-engineering-meetup/events/290681404/"
+                                target="_blank"
+                                rel="noopener noreferrer">
                                 <img src="/imgs/news-slide-lightning-talks.png" class="d-block w-100" alt="...">
                             </a>
                         </div>


### PR DESCRIPTION
Fixes the issue of the Lightning Talks slide opening its link in the current tab; it now opens in a new tab.