### PR TITLE
Fix footer's box-shadow color

### DIFF
--- a/css/website-base.css
+++ b/css/website-base.css
@@ -5,5 +5,5 @@
 footer {
     height: 90px;
     /* In case page doesn't extend to bottom of screen. */
-    box-shadow: 0 50vh 0 50vh #212529;
+    box-shadow: 0 50vh 0 50vh #292929;
 }


### PR DESCRIPTION
The footer's box-shadow color does not match its background color. Change the footer's box-shadow color to match its background color so that when the content doesn't reach the bottom of the page, you do not see different colors.