### PR TITLE
Remove Jacob Banuelos from about-us.html

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -120,22 +120,6 @@
                             In his free time, Chase likes to hike, watch YouTube, and learn more about programming.
                         </p>
                     </div>
-                    <div class="row">
-                        <h4 class="col-12 mt-3">
-                            Jacob Bañuelos, Vice President
-                        </h4>
-                    </div>
-                    <div class="row">
-                        <div class="col-sm-5 col-md-4">
-                            <img class="w-100" src="imgs/jacob-banuelos.bmp" alt="...">
-                        </div>
-                        <p class="col-sm-7 col-md-8 mt-2 mt-sm-0">
-                            Jacob is currently a Junior at Utah Valley University studying for a Bachelor of Science in Computer Science.
-                            He's passionate about learning and teaching people how to program.
-                            After Jacob graduates with his B.S. in Computer Science, he is considering on pursuing a Master's degree in Computer Science with an emphasis in machine learning.
-                            In his free time, Jacob enjoys playing the piano, listening to music, and going to concerts.
-                        </p>
-                    </div>
                 </section>
             </div>
             <div class="col-md-1 col-lg-2 col-xxl-3"></div>


### PR DESCRIPTION
Remove the entry for Jacob Banuelos on the `About Us` page since he is no longer the club's Vice President.